### PR TITLE
added failing test to cover required: true bug

### DIFF
--- a/test/parser.js
+++ b/test/parser.js
@@ -1434,6 +1434,39 @@ describe('Parser', function() {
           ]
         }).and.notify(done);
       });
+      it('defaults query parameters requiredness to falsy', function(done) {
+        var definition = [
+          '#%RAML 0.2',
+          '---',
+          'title: Test',
+          'baseUri: http://myapi.org',
+          '/resource:',
+          '  get:',
+          '    queryParameters:',
+          '      notRequired:',
+          '        type: integer'
+        ].join('\n');
+
+        raml.load(definition).should.become({
+          title: 'Test',
+          baseUri: 'http://myapi.org',
+          resources: [
+            {
+              relativeUri: "/resource",
+              methods: [{
+                method: "get",
+                queryParameters: {
+                  notRequired: {
+                    displayName: 'notRequired',
+                    type: 'integer'
+                  }
+                }
+              }]
+            }
+          ]
+        }).and.notify(done);
+      });
+
       it('should fail when a parameter uses array syntax with only one type', function(done) {
         var definition = [
           '#%RAML 0.2',


### PR DESCRIPTION
I uncovered an issue in the parser when working on documentation for the console - every query parameter ends up coming from the parser as required. This pull request adds a failing spec which shows the problem.
