### PR TITLE
Allow multiple levels of optional definitions

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -142,8 +142,11 @@ class @MappingNode extends @CollectionNode
               ownNodeProperty[1] = nonNullNode
 
             ownNodeProperty[1].combine resourceProperty[1]
-            # remove the '?' at the end of the property name
-            ownNodeProperty[0].value = ownNodeProperty[0].value.replace /\?$/, ''
+            # check if the property should still end in '?'
+            unless (ownNodeProperty[0].value.slice(-1) == '?') and
+                   (resourceProperty[0].value.slice(-1) == '?')
+              # remove the '?' at the end of the property name
+              ownNodeProperty[0].value = ownNodeProperty[0].value.replace /\?$/, ''
       else
         @value.push [resourceProperty[0].clone(), resourceProperty[1].clone()]
 


### PR DESCRIPTION
As far as @abalmos and I can tell, this change fixes the bug. However we are by no means coffeescript programmers, so it might not be the best way to fix it...

Below is a minimal example which would not work before this commit.
`/files` would have a GET method, but it should not.

``` yaml
#%RAML 0.8
title: Title
resourceTypes:
  - common:
      get?:
  - base:
      type: common
      get?:
/files:
    type: base
```

After this commit, `/files` has no GET method.
