### PR TITLE
Updating inline RAML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ you can also alternatively load from a string containing the api definition:
   var raml = require('raml-parser');
   
   var definition = [
+    '#%RAML 0.8',
     '---',
     'title: MyApi',
     'baseUri: http://myapi.com',
-    '/:',
-    '  name: Root'
+    '/Root:'
   ].join('\n');
   
   raml.load(definition).then( function(data) {
@@ -78,11 +78,11 @@ you can also alternatively generate an AST from a string containing the api defi
   var raml = require('raml-parser');
   
   var definition = [
+    '#%RAML 0.8',
     '---',
     'title: MyApi',
     'baseUri: http://myapi.com',
-    '/:',
-    '  name: Root'
+    '/Root:'
   ].join('\n');
   
   raml.compose(definition).then( function(rootNode) {


### PR DESCRIPTION
The README was out of date with the current version of the `raml-js-parser` hosted on `npmjs.org` (which matches the Github repo's version number, so I assume they're synced). The parser requires a a `'#%RAML 0.8'` string in the first line. I added that, but then it also threw the following once the version string was added:

```
Error parsing: while validating resources
property: 'name' is invalid in a resource
```

By changing the resource name to the explicit value (rather than the key-value pair that seems to be in the current docs), it seems to parse correctly as valid RAML.
