### PR TITLE
Avoid arbitrarily blocking file load protocols

### DIFF
--- a/lib/raml.js
+++ b/lib/raml.js
@@ -36,24 +36,13 @@
 
 
     FileReader.prototype.readFileAsync = function(file) {
-      var targerUrl;
       if (this.readFileAsyncOverride) {
         return this.readFileAsyncOverride(file);
       }
-      targerUrl = this.url.parse(file);
-      if (targerUrl.protocol != null) {
-        if (!targerUrl.protocol.match(/^https?/i)) {
-          throw new exports.FileError("while reading " + file, null, "unknown protocol " + targerUrl.protocol, this.start_mark);
-        } else {
-          return this.fetchFileAsync(file);
-        }
-      } else {
-        if (typeof window !== "undefined" && window !== null) {
-          return this.fetchFileAsync(file);
-        } else {
-          return this.fetchLocalFileAsync(file);
-        }
+      if (/^https?/i.test(file) || (typeof window !== "undefined" && window !== null)) {
+        return this.fetchFileAsync(file);
       }
+      return this.fetchLocalFileAsync(file);
     };
 
     /*

--- a/src/raml.coffee
+++ b/src/raml.coffee
@@ -19,17 +19,10 @@ class @FileReader
     if @readFileAsyncOverride
       return @readFileAsyncOverride(file)
 
-    targerUrl = @url.parse(file)
-    if targerUrl.protocol?
-      unless targerUrl.protocol.match(/^https?/i)
-        throw new exports.FileError "while reading #{file}", null, "unknown protocol #{targerUrl.protocol}", @start_mark
-      else
-        return @fetchFileAsync file
-    else
-      if window?
-        return @fetchFileAsync file
-      else
-        return @fetchLocalFileAsync file
+    if (/^https?/i).test(file) or window?
+      return @fetchFileAsync file
+
+    return @fetchLocalFileAsync file
 
   ###
   Read file from the disk.

--- a/test/specs/local.js
+++ b/test/specs/local.js
@@ -1,11 +1,12 @@
-"use strict"
+'use strict';
 
 if (typeof window === 'undefined') {
-    var raml = require('../../lib/raml.js')
-    var chai = require('chai')
-        , expect = chai.expect
-        , should = chai.should();
-    var chaiAsPromised = require("chai-as-promised");
+    var raml = require('../../lib/raml.js');
+    var chai = require('chai');
+    var q = require('q');
+    var chaiAsPromised = require('chai-as-promised');
+
+    chai.should();
     chai.use(chaiAsPromised);
 } else {
     var raml = RAML.Parser;
@@ -20,6 +21,25 @@ describe('Parser', function() {
                 documentation: [
                     { title: 'Getting Started', content: '# Getting Started\n\nThis is a getting started guide.' }
                 ]
+            }).and.notify(done);
+        });
+
+        it('should succeed with windows file systems', function (done) {
+            var expectedPath = 'C:\\Users\\test\\example.raml';
+
+            var document = [
+                '#%RAML 0.8',
+                'title: Example API'
+            ].join('\n');
+
+            var reader = new raml.FileReader(function (path) {
+              path.should.equal(expectedPath);
+
+              return q(document);
+            });
+
+            raml.loadFile(expectedPath, { reader: reader }).should.eventually.deep.equal({
+                title: 'Example API'
             }).and.notify(done);
         });
     });


### PR DESCRIPTION
Moves dependency onto file reader for file read errors.

Fixes https://github.com/raml-org/raml-js-parser/issues/120 and https://github.com/mulesoft/raml-client-generator/issues/6