### PR TITLE
Add support for parameter 'description' in request 'body'

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1194,6 +1194,11 @@
               valid = false;
           }
           switch (key) {
+            case "description":
+              if (!util.isScalar(property[1])) {
+                throw new exports.ValidationError('while validating body', null, 'body description must be a string', bodyProperty[1].start_mark);
+              }
+              break;
             case "example":
               if (bodyMode && __indexOf.call(implicitMode, bodyMode) < 0) {
                 throw new exports.ValidationError('while validating body', null, "not compatible with explicit Media Type", bodyProperty[0].start_mark);

--- a/src/validator.coffee
+++ b/src/validator.coffee
@@ -750,6 +750,9 @@ class @Validator
             valid = false
 
         switch key
+          when "description"
+            unless util.isScalar property[1]
+              throw new exports.ValidationError 'while validating body', null, 'body description must be a string', bodyProperty[1].start_mark
           when "example"
             if bodyMode and bodyMode not in implicitMode
               throw new exports.ValidationError 'while validating body', null, "not compatible with explicit Media Type", bodyProperty[0].start_mark


### PR DESCRIPTION
Hi,

the raml specification allows description in body, but this validator didnt have the function implement.

I'm not familiar with this project much, so I updated only `validator.coffee` - should I update elsewhere?

[RAML spec - Named parameters](https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#named-parameters) ... for the following properties: URI parameters, query string parameters, form parameters, **request bodies** (depending on the media type), and request and response headers. 



btw, the `grunt` build failed on windows, so the dist file isnt enclosed
![image](https://cloud.githubusercontent.com/assets/385047/7042220/807cf374-dde0-11e4-95ac-ebdfd673c37b.png)